### PR TITLE
Distinguish module from Swift Charts with podspec

### DIFF
--- a/Charts.podspec
+++ b/Charts.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "Charts"
   s.version = "4.1.0"
+  s.module_name = "DGCharts"
   s.summary = "Charts is a powerful & easy to use chart library for iOS, tvOS and OSX (and Android)"
   s.homepage = "https://github.com/danielgindi/Charts"
   s.license = { :type => "Apache License, Version 2.0", :file => "LICENSE" }


### PR DESCRIPTION
As per temporary solution proposed [here](https://github.com/danielgindi/Charts/issues/4897#issuecomment-1240652977) we rename a module on pod spec to distinguish from recently-introduced [Swift Charts](https://developer.apple.com/documentation/charts) library. The hack provides a way to support both libraries on the main project and opens the path to step-by-step migration to the latter.

Related to https://github.com/danielgindi/Charts/issues/4897